### PR TITLE
fix #37 - added support for different status codes

### DIFF
--- a/service.js
+++ b/service.js
@@ -5,6 +5,10 @@ var zmq = require('zmq'),
     _ = require('lodash'),
     Message = require('zmq-service-suite-message');
 
+function isValidSuccessCode(code){
+  return code >= 200 && code < 300;
+}
+
 var ZSSService = function(configuration){
 
   var log = Logger.getLogger('ZSSService');
@@ -116,10 +120,14 @@ var ZSSService = function(configuration){
     try {
       verb(msg.payload, msg, function(err, payload){
         if (err) { return replyServiceError(err, msg); }
+        if (msg.status && !isValidSuccessCode(msg.status)){
+          log.warn(msg, "The service returned a invalid success status code: %s", msg.status);
+          return replyErrorCode(500, msg);
+        }
 
         msg.payload = payload;
         // reply with success message
-        msg.status = 200;
+        msg.status = msg.status || 200;
         reply(msg);
       });
     }

--- a/spec/unit/service_spec.js
+++ b/spec/unit/service_spec.js
@@ -816,7 +816,7 @@ describe("ZSSService", function(){
         };
       });
 
-      it('returns status code 200 on successfull service execution', function(done) {
+      it('returns status code 200 when not specified', function(done) {
         socketMock.send = function(frames) {
           if(frames[TYPE_FRAME] === Message.Type.REP) {
             expect(frames[STATUS_FRAME]).toEqual(200);
@@ -828,6 +828,42 @@ describe("ZSSService", function(){
         var target = new ZSSService(config);
         target.addVerb('ping', function(payload, message, callback){
           callback(null, "PONG");
+        });
+
+        target.run();
+      });
+
+      it('returns the status code specified by the service', function(done) {
+        socketMock.send = function(frames) {
+          if(frames[TYPE_FRAME] === Message.Type.REP) {
+            expect(frames[STATUS_FRAME]).toEqual(204);
+            done();
+          }
+        };
+        spyOn(zmq, 'socket').andReturn(socketMock);
+
+        var target = new ZSSService(config);
+        target.addVerb('ping', function(payload, message, callback){
+          message.status = 204;
+          callback(null, null);
+        });
+
+        target.run();
+      });
+
+      it('returns 500  when the status code specified by the service is not valid', function(done) {
+        socketMock.send = function(frames) {
+          if(frames[TYPE_FRAME] === Message.Type.REP) {
+            expect(frames[STATUS_FRAME]).toEqual(500);
+            done();
+          }
+        };
+        spyOn(zmq, 'socket').andReturn(socketMock);
+
+        var target = new ZSSService(config);
+        target.addVerb('ping', function(payload, message, callback){
+          message.status = 400;
+          callback(null, null);
         });
 
         target.run();


### PR DESCRIPTION
The service library should be revisited and refactored, currently
headers and status code replies are done by reference and sharing the
object, this would be more clean if done by contract of the returned
data from the service.